### PR TITLE
🎠 download model permission fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN pip3 --no-cache-dir install -r /tmp/requirements.txt
 
 # Download models
 ADD server/models/download_models.sh /tmp/models/
+RUN chmod +x /tmp/models/download_models.sh
 RUN cd /tmp/models && ./download_models.sh
 
 # Add project and change directory


### PR DESCRIPTION
# 🎠 download model permission fix

As ```download_models.sh``` has proper execution permission, it is often not updated to github and new user will git clone a ```download_models.sh``` file without execution permission.

Hence this will lead to the original author successfully build the docker image, but other users won't

resolve #26 